### PR TITLE
Hotfix SceneNav methods

### DIFF
--- a/src/application/GameController.java
+++ b/src/application/GameController.java
@@ -1,7 +1,5 @@
 package application;
 
-import java.util.ArrayList;
-
 public class GameController {
     private static GameController instance;
     private int soundValue;

--- a/src/application/Main.java
+++ b/src/application/Main.java
@@ -17,7 +17,7 @@ public class Main extends Application {
         Main.stage = stage;
         stage.setTitle("Shooting Game");
         stage.setResizable(false);
-        SceneNav.setScene("MainMenu");
+        SceneNav.setFXMLScene("MainMenu.fxml");
         stage.show();
     }
 

--- a/src/scene/MainMenuController.java
+++ b/src/scene/MainMenuController.java
@@ -16,6 +16,6 @@ public class MainMenuController {
 
     @FXML
     private void toSetting() {
-        SceneNav.setScene("SettingWindow");
+        SceneNav.setFXMLScene("SettingWindow.fxml");
     }
 }

--- a/src/scene/SettingWindowController.java
+++ b/src/scene/SettingWindowController.java
@@ -38,6 +38,6 @@ public class SettingWindowController {
 
     @FXML
     private void backToMainMenu() {
-        SceneNav.setScene("MainMenu");
+        SceneNav.setFXMLScene("MainMenu.fxml");
     }
 }

--- a/src/utils/SceneNav.java
+++ b/src/utils/SceneNav.java
@@ -2,13 +2,14 @@ package utils;
 
 import application.Main;
 import javafx.fxml.FXMLLoader;
+import javafx.scene.Node;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
 
 import java.io.IOException;
 
 public class SceneNav {
-    public static void setScene(String target) {
+    public static void setFXMLScene(String target) {
         try {
             FXMLLoader loader = new FXMLLoader(SceneNav.class.getResource("/scene/" + target + ".fxml"));
             Parent root = loader.load();
@@ -16,5 +17,10 @@ public class SceneNav {
             Main.getStage().setScene(scene);
         } catch (IOException ignored) {
         }
+    }
+
+    public static void setJavaScene(Node root) {
+        Scene scene = new Scene((Parent) root, 1000, 800);
+        Main.getStage().setScene(scene);
     }
 }


### PR DESCRIPTION
- SceneNav.setScene(String target) method has been changed to
SceneNav.setFXMLScene(String target) with the same utility
- new SceneNav.setJavaScene(Node root) for JavaFX files that was not built in Scene Builder